### PR TITLE
refactor: returns synth2_plugin_t instead of clap_plugin_t

### DIFF
--- a/include/synth2/plugin.h
+++ b/include/synth2/plugin.h
@@ -41,8 +41,7 @@ typedef struct synth2_plugin {
 /// Descriptor of synth2 plugin.
 extern const clap_plugin_descriptor_t synth2_plugin_descriptor;
 
-/// Create plugin, return pointer to clap_plugin_t.
-/// plugin_data holds pointer to synth2_plugin_t.
-const clap_plugin_t *synth2_plugin_create(const clap_host_t *host);
+/// Create plugin, return pointer to it.
+const synth2_plugin_t *synth2_plugin_create(const clap_host_t *host);
 
 #endif  // SYNTH2_PLUGIN_H_

--- a/src/factory/plugin-factory.c
+++ b/src/factory/plugin-factory.c
@@ -41,7 +41,8 @@ static const clap_plugin_t *synth2_plugin_factory_create_plugin(
     const char *plugin_id
 ) {
     if (strcmp(plugin_id, synth2_plugin_descriptor.id) == 0) {
-        return synth2_plugin_create(host);
+        const synth2_plugin_t *plugin = synth2_plugin_create(host);
+        return plugin ? &plugin->plugin : NULL;
     } else {
         return NULL;
     }

--- a/src/plugin.c
+++ b/src/plugin.c
@@ -174,7 +174,7 @@ const clap_plugin_descriptor_t synth2_plugin_descriptor = {
     .features = synth2_plugin_descriptor_features,
 };
 
-const clap_plugin_t *synth2_plugin_create(const clap_host_t *host) {
+const synth2_plugin_t *synth2_plugin_create(const clap_host_t *host) {
     synth2_plugin_t *plugin = calloc(1, sizeof(synth2_plugin_t));
     if (!plugin) return NULL;
 
@@ -192,5 +192,5 @@ const clap_plugin_t *synth2_plugin_create(const clap_host_t *host) {
     plugin->plugin.get_extension = synth2_plugin_get_extension;
     plugin->plugin.on_main_thread = synth2_plugin_on_main_thread;
 
-    return &plugin->plugin;
+    return plugin;
 }


### PR DESCRIPTION
synth2_plugin_create is provided in file contains synth2_plugin_t, so returns synth2_plugin_t will make sense instead of clap_plugin_t