### PR TITLE
refactor: remove synth2 prefix from static function

### DIFF
--- a/src/entry.c
+++ b/src/entry.c
@@ -17,15 +17,15 @@
 
 #include "synth2/factory/plugin-factory.h"
 
-static bool synth2_entry_init(const char *plugin_path) {
+static bool entry_init(const char *plugin_path) {
     return true;
 }
 
-static void synth2_entry_deinit(void) {
+static void entry_deinit(void) {
     return;
 }
 
-static const void *synth2_entry_get_factory(const char *factory_id) {
+static const void *entry_get_factory(const char *factory_id) {
     if (strcmp(factory_id, CLAP_PLUGIN_FACTORY_ID) == 0) {
         return &synth2_plugin_factory;
     } else {
@@ -35,7 +35,7 @@ static const void *synth2_entry_get_factory(const char *factory_id) {
 
 const clap_plugin_entry_t clap_entry = {
     .clap_version = CLAP_VERSION_INIT,
-    .init = synth2_entry_init,
-    .deinit = synth2_entry_deinit,
-    .get_factory = synth2_entry_get_factory,
+    .init = entry_init,
+    .deinit = entry_deinit,
+    .get_factory = entry_get_factory,
 };

--- a/src/ext/audio-ports.c
+++ b/src/ext/audio-ports.c
@@ -16,12 +16,11 @@
 
 #include <string.h>
 
-static uint32_t
-synth2_plugin_audio_ports_count(const clap_plugin_t *plugin, bool is_input) {
+static uint32_t audio_ports_count(const clap_plugin_t *plugin, bool is_input) {
     return is_input ? 0 : 1;
 }
 
-static bool synth2_plugin_audio_ports_get(
+static bool audio_ports_get(
     const clap_plugin_t *plugin,
     uint32_t index,
     bool is_input,
@@ -40,6 +39,6 @@ static bool synth2_plugin_audio_ports_get(
 }
 
 const clap_plugin_audio_ports_t synth2_plugin_audio_ports = {
-    .count = synth2_plugin_audio_ports_count,
-    .get = synth2_plugin_audio_ports_get,
+    .count = audio_ports_count,
+    .get = audio_ports_get,
 };

--- a/src/ext/note-ports.c
+++ b/src/ext/note-ports.c
@@ -16,12 +16,11 @@
 
 #include <string.h>
 
-static uint32_t
-synth2_plugin_note_ports_count(const clap_plugin_t *plugin, bool is_input) {
+static uint32_t note_ports_count(const clap_plugin_t *plugin, bool is_input) {
     return is_input ? 1 : 0;
 }
 
-static bool synth2_plugin_note_ports_get(
+static bool note_ports_get(
     const clap_plugin_t *plugin,
     uint32_t index,
     bool is_input,
@@ -38,6 +37,6 @@ static bool synth2_plugin_note_ports_get(
 }
 
 const clap_plugin_note_ports_t synth2_plugin_note_ports = {
-    .count = synth2_plugin_note_ports_count,
-    .get = synth2_plugin_note_ports_get,
+    .count = note_ports_count,
+    .get = note_ports_get,
 };

--- a/src/ext/params.c
+++ b/src/ext/params.c
@@ -19,28 +19,22 @@
 #include "synth2/plugin.h"
 #include "synth2/process-event.h"
 
-static uint32_t synth2_plugin_params_count(const clap_plugin_t *plugin) {
+static uint32_t params_count(const clap_plugin_t *plugin) {
     return SYNTH2_NUM_PARAMS;
 }
 
-static bool synth2_plugin_params_get_info(
-    const clap_plugin_t *plugin,
-    uint32_t index,
-    clap_param_info_t *info
-) {
+static bool
+params_get_info(const clap_plugin_t *plugin, uint32_t index, clap_param_info_t *info) {
     return synth2_params_get_info(index, info);
 }
 
-static bool synth2_plugin_params_get_value(
-    const clap_plugin_t *plugin,
-    clap_id param_id,
-    double *out_value
-) {
+static bool
+params_get_value(const clap_plugin_t *plugin, clap_id param_id, double *out_value) {
     const synth2_plugin_t *plug = plugin->plugin_data;
     return synth2_params_get_value(&plug->params, param_id, out_value);
 }
 
-static bool synth2_plugin_params_value_to_text(
+static bool params_value_to_text(
     const clap_plugin_t *plugin,
     clap_id param_id,
     double value,
@@ -50,7 +44,7 @@ static bool synth2_plugin_params_value_to_text(
     return synth2_params_value_to_text(param_id, value, out_buffer, out_buffer_capacity);
 }
 
-static bool synth2_plugin_params_text_to_value(
+static bool params_text_to_value(
     const clap_plugin_t *plugin,
     clap_id param_id,
     const char *param_value_text,
@@ -59,7 +53,7 @@ static bool synth2_plugin_params_text_to_value(
     return synth2_params_text_to_value(param_id, param_value_text, out_value);
 }
 
-static void synth2_plugin_params_flush(
+static void params_flush(
     const clap_plugin_t *plugin,
     const clap_input_events_t *in,
     const clap_output_events_t *out
@@ -73,10 +67,10 @@ static void synth2_plugin_params_flush(
 }
 
 const clap_plugin_params_t synth2_plugin_params = {
-    .count = synth2_plugin_params_count,
-    .get_info = synth2_plugin_params_get_info,
-    .get_value = synth2_plugin_params_get_value,
-    .value_to_text = synth2_plugin_params_value_to_text,
-    .text_to_value = synth2_plugin_params_text_to_value,
-    .flush = synth2_plugin_params_flush,
+    .count = params_count,
+    .get_info = params_get_info,
+    .get_value = params_get_value,
+    .value_to_text = params_value_to_text,
+    .text_to_value = params_text_to_value,
+    .flush = params_flush,
 };

--- a/src/factory/plugin-factory.c
+++ b/src/factory/plugin-factory.c
@@ -18,13 +18,11 @@
 
 #include "synth2/plugin.h"
 
-static uint32_t synth2_plugin_factory_get_plugin_count(
-    const clap_plugin_factory_t *factory
-) {
+static uint32_t plugin_factory_get_plugin_count(const clap_plugin_factory_t *factory) {
     return 1;
 }
 
-static const clap_plugin_descriptor_t *synth2_plugin_factory_get_plugin_descriptor(
+static const clap_plugin_descriptor_t *plugin_factory_get_plugin_descriptor(
     const clap_plugin_factory_t *factory,
     uint32_t index
 ) {
@@ -35,7 +33,7 @@ static const clap_plugin_descriptor_t *synth2_plugin_factory_get_plugin_descript
     }
 }
 
-static const clap_plugin_t *synth2_plugin_factory_create_plugin(
+static const clap_plugin_t *plugin_factory_create_plugin(
     const struct clap_plugin_factory *factory,
     const clap_host_t *host,
     const char *plugin_id
@@ -49,7 +47,7 @@ static const clap_plugin_t *synth2_plugin_factory_create_plugin(
 }
 
 const clap_plugin_factory_t synth2_plugin_factory = {
-    .get_plugin_count = synth2_plugin_factory_get_plugin_count,
-    .get_plugin_descriptor = synth2_plugin_factory_get_plugin_descriptor,
-    .create_plugin = synth2_plugin_factory_create_plugin,
+    .get_plugin_count = plugin_factory_get_plugin_count,
+    .get_plugin_descriptor = plugin_factory_get_plugin_descriptor,
+    .create_plugin = plugin_factory_create_plugin,
 };

--- a/src/plugin.c
+++ b/src/plugin.c
@@ -25,7 +25,7 @@
 #include "synth2/process-event.h"
 #include "synth2/render-audio.h"
 
-static bool synth2_plugin_init(const clap_plugin_t *plugin) {
+static bool plugin_init(const clap_plugin_t *plugin) {
     synth2_plugin_t *plug = plugin->plugin_data;
     plug->params = synth2_params_default_value;
 
@@ -38,12 +38,12 @@ static bool synth2_plugin_init(const clap_plugin_t *plugin) {
     return true;
 }
 
-static void synth2_plugin_destroy(const clap_plugin_t *plugin) {
+static void plugin_destroy(const clap_plugin_t *plugin) {
     synth2_plugin_t *plug = plugin->plugin_data;
     free(plug);
 }
 
-static bool synth2_plugin_activate(
+static bool plugin_activate(
     const clap_plugin_t *plugin,
     double sample_rate,
     uint32_t min_frames_count,
@@ -54,24 +54,24 @@ static bool synth2_plugin_activate(
     return true;
 }
 
-static void synth2_plugin_deactivate(const clap_plugin_t *plugin) {
+static void plugin_deactivate(const clap_plugin_t *plugin) {
     return;
 }
 
-static bool synth2_plugin_start_processing(const clap_plugin_t *plugin) {
+static bool plugin_start_processing(const clap_plugin_t *plugin) {
     return true;
 }
 
-static void synth2_plugin_stop_processing(const clap_plugin_t *plugin) {
+static void plugin_stop_processing(const clap_plugin_t *plugin) {
     return;
 }
 
-static void synth2_plugin_reset(const clap_plugin_t *plugin) {
+static void plugin_reset(const clap_plugin_t *plugin) {
     return;
 }
 
 static clap_process_status
-synth2_plugin_process(const clap_plugin_t *plugin, const clap_process_t *process) {
+plugin_process(const clap_plugin_t *plugin, const clap_process_t *process) {
     synth2_plugin_t *plug = plugin->plugin_data;
 
     assert(process->audio_inputs_count == 0);
@@ -135,8 +135,7 @@ synth2_plugin_process(const clap_plugin_t *plugin, const clap_process_t *process
     return CLAP_PROCESS_CONTINUE;
 }
 
-static const void *
-synth2_plugin_get_extension(const clap_plugin_t *plugin, const char *id) {
+static const void *plugin_get_extension(const clap_plugin_t *plugin, const char *id) {
     if (strcmp(id, CLAP_EXT_AUDIO_PORTS) == 0) {
         return &synth2_plugin_audio_ports;
     } else if (strcmp(id, CLAP_EXT_NOTE_PORTS) == 0) {
@@ -148,12 +147,12 @@ synth2_plugin_get_extension(const clap_plugin_t *plugin, const char *id) {
     }
 }
 
-static void synth2_plugin_on_main_thread(const clap_plugin_t *plugin) {
+static void plugin_on_main_thread(const clap_plugin_t *plugin) {
     return;
 }
 
 // clang-format off
-static const char *synth2_plugin_descriptor_features[] = {
+static const char *features[] = {
     CLAP_PLUGIN_FEATURE_INSTRUMENT,
     CLAP_PLUGIN_FEATURE_SYNTHESIZER,
     CLAP_PLUGIN_FEATURE_STEREO,
@@ -171,7 +170,7 @@ const clap_plugin_descriptor_t synth2_plugin_descriptor = {
     .support_url = NULL,
     .version = "0.1.0",
     .description = "Yet another synthesizer",
-    .features = synth2_plugin_descriptor_features,
+    .features = features,
 };
 
 const synth2_plugin_t *synth2_plugin_create(const clap_host_t *host) {
@@ -181,16 +180,16 @@ const synth2_plugin_t *synth2_plugin_create(const clap_host_t *host) {
     plugin->host = host;
     plugin->plugin.desc = &synth2_plugin_descriptor;
     plugin->plugin.plugin_data = plugin;
-    plugin->plugin.init = synth2_plugin_init;
-    plugin->plugin.destroy = synth2_plugin_destroy;
-    plugin->plugin.activate = synth2_plugin_activate;
-    plugin->plugin.deactivate = synth2_plugin_deactivate;
-    plugin->plugin.start_processing = synth2_plugin_start_processing;
-    plugin->plugin.stop_processing = synth2_plugin_stop_processing;
-    plugin->plugin.reset = synth2_plugin_reset;
-    plugin->plugin.process = synth2_plugin_process;
-    plugin->plugin.get_extension = synth2_plugin_get_extension;
-    plugin->plugin.on_main_thread = synth2_plugin_on_main_thread;
+    plugin->plugin.init = plugin_init;
+    plugin->plugin.destroy = plugin_destroy;
+    plugin->plugin.activate = plugin_activate;
+    plugin->plugin.deactivate = plugin_deactivate;
+    plugin->plugin.start_processing = plugin_start_processing;
+    plugin->plugin.stop_processing = plugin_stop_processing;
+    plugin->plugin.reset = plugin_reset;
+    plugin->plugin.process = plugin_process;
+    plugin->plugin.get_extension = plugin_get_extension;
+    plugin->plugin.on_main_thread = plugin_on_main_thread;
 
     return plugin;
 }


### PR DESCRIPTION
synth2 is prepended to prevent function name collision and represent the function is provided by this library. But static function is not exposed to outer, so remove synth2 from these.