### PR TITLE
chore: remove generation of dummy source file

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -12,7 +12,6 @@ add_library(synth2 MODULE
     plugin.c
     process-event.c
     render-audio.c
-    voice.c
 )
 
 # Collect libraries for target_link_libraries.
@@ -23,10 +22,6 @@ endif()
 
 target_include_directories(synth2 PUBLIC ${CMAKE_SOURCE_DIR}/include)
 target_link_libraries(synth2 ${SYNTH2_LINK_LIBRARIES})
-
-# Clangd can't recognize voice.h is on this project without correspond source file.
-# So create a empty source file corresponds to it at configure time to solve the problem.
-file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/voice.c" "")
 
 set_target_properties(synth2 PROPERTIES
     PREFIX ""


### PR DESCRIPTION
Currently clangd doesn't claim anything to voice.h, so hack is not necessary anymore.